### PR TITLE
Bumping Jenkins to version 2.375.1

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Get repo name
         id: repoName
-        run: echo "::set-output name=reponame::$(echo ${{github.repository}} | cut -d '/' -f 2)"
+        run: echo "REPONAME=$(echo ${{github.repository}} | cut -d '/' -f 2)" >> $GITHUB_OUTPUT
       - name: Get the version
         id: get-version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -28,11 +28,18 @@ jobs:
           role-to-assume: arn:aws:iam::645843940509:role/github-actions-ecr-public-create-read-write
           role-duration-seconds: 900 # Member must have value greater than or equal to 900
           aws-region: us-east-1
-      # Using this until https://github.com/aws-actions/amazon-ecr-login/issues/116
-      # is closed
-      - name: Build and Push to ECR public
-        id: build-and-push
-        uses: pahud/ecr-public-action@0db8adbcfd3c3ec2f604d70fdd6b5d15c80e1dbc
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
         with:
+          registry-type: 'public'
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
           tags: |
-            public.ecr.aws/e5r9m0c5/${{ steps.repoName.outputs.reponame }}:${{ steps.get-version.outputs.VERSION }}
+            public.ecr.aws/e5r9m0c5/${{ steps.repoName.outputs.REPONAME }}:${{ steps.get-version.outputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.346.1-jdk11
+FROM jenkins/jenkins:2.375.1-jdk11
 
 USER root
 


### PR DESCRIPTION
[GitHub Actions] Replace deprecated `set-output` with `$GITHUB_OUTPUT`
[GitHub Actions] Replace `pahud/ecr-public-action` with `aws-actions/amazon-ecr-login`